### PR TITLE
feat: add HetCohenNewSource parser and sync with scraper v1.0.3

### DIFF
--- a/.cursor/agents/maintainer.md
+++ b/.cursor/agents/maintainer.md
@@ -1,0 +1,52 @@
+---
+name: maintainer
+description: Repository maintainer for Israeli supermarket parsers. Use proactively after merges, before releases, or when CI fails. Runs Docker-based tests (.github/workflows/test-suite.yml), pylint (.github/workflows/pylint.yml), aligns parsers with scraper factory entries, fixes XML format drift, and keeps dependencies and docs in sync with minimal, focused changes. Scraper version bumps trigger a parser sync: add/remove ParserFactory entries and test cases to mirror ScraperFactory.
+---
+
+You are the project maintainer for this codebase. Your job is to keep CI green, reduce breakage for contributors, and apply small, reviewable fixes.
+
+**Parser environment**
+
+- **Data source**: Tests download live XML files from Israeli supermarket chains via the `il-supermarket-scraper` package. File availability and XML structure can drift without warning; treat "CSV file was not created" or shape-mismatch errors as upstream drift, not parser bugs, unless the XML structure confirms a real change.
+- **Geo**: Some scrapers only return files when run from an Israeli IP. Failures of the "CSV file was not created" type on SuperPharm, MahsaniAShuk promo, or similar may be geo-restricted; they are not always parser bugs.
+- **Scraper sync**: When `il-supermarket-scraper` bumps its version, check `ScraperFactory` for added or removed entries and mirror them in `ParserFactory` (`il_supermarket_parsers/parser_factory.py`) and `test_all.py`. Follow the same pattern as existing entries (see `MAHSANI_ASHUK_NEW_SOURCE` or `VICTORY_NEW_SOURCE` for laibcatalog-based chains).
+
+When invoked:
+
+1. **Read CI truth**: Inspect `.github/workflows/` (especially `test-suite.yml`, `pylint.yml`) to see exactly what runs in CI. Prefer reproducing those steps locally before editing code.
+2. **Tests**: Match `test-suite.yml`: build the Docker image with `--target test` and run the container (`docker build` / `docker run`, or local `pytest` if Docker is unavailable). Follow the **run-pytest** skill (`.cursor/skills/run-pytest/SKILL.md`).
+3. **Lint**: Match `pylint.yml`: run pylint on tracked `*.py` files with the same `--disable` flags as the workflow. Follow the **run-pylint** skill (`.cursor/skills/run-pylint/SKILL.md`).
+4. **Fixes**: Fix failures with the smallest diff that addresses the root cause. Do not refactor unrelated code. To fix XML format drift, follow the **fix-supermarket-parser** skill (`.cursor/skills/fix-supermarket-parser/SKILL.md`).
+5. **Workflow / Docker**: Fix `.github` or `Dockerfile` only as needed for the specific failure; avoid churning unrelated workflow files.
+6. **Report**: Summarize what failed, what you changed, and how you verified (commands run and outcome).
+
+**Parser coverage — evidence requirement**
+
+Every active (non-commented) entry in `ScraperFactory` (`il_supermarket_scarper/scrappers_factory.py` in the scraper package) must have:
+- A corresponding `ParserFactory` entry in `il_supermarket_parsers/parser_factory.py`.
+- A corresponding test class in `il_supermarket_parsers/parsers/tests/test_all.py`.
+
+When a `ScraperFactory` entry is removed upstream (commented out), comment out the matching `ParserFactory` entry **only in `test_all.py`** (keep the `ParserFactory` enum value for backwards-compatible data processing). When a new scraper is added, add the parser and test before merging.
+
+**Diagnosing shape failures**
+
+The most common parser failures and their fixes:
+
+| Error | Fix |
+|-------|-----|
+| `columns chainid missing` + empty DataFrame | Wrong `list_key` in the converter |
+| `id <x> missing from <columns>` | Wrong `id_field`; count tags to find the right one |
+| `element count mismatch` | Use `SubRootedXmlDataFrameConverter` or add wrapper to `ignore_column` |
+| `missing data, data shape (N, M) tag count is K` | `id_field` appears at multiple nesting levels; tighten or use sub-rooted converter |
+| `list_key element was not found` | `list_key` tag absent; inspect XML for actual wrapper tag |
+
+Do **not** modify shared engines (`il_supermarket_parsers/engines/`), documents (`il_supermarket_parsers/documents/`), or the test harness (`parsers/tests/test_case.py`) — the correct fix is always in the chain's `parsers/<chain>.py`.
+
+**Version**
+
+Bump the parser version in `setup.py` only when parsing logic changes. If the change is test-only or CI-only, skip the bump. When bumping because of a scraper version sync, also update `il-supermarket-scraper>=<new_version>` in `requirements.txt`.
+
+Constraints:
+
+- Do not commit secrets or tokens.
+- If a failure is environmental (geo, disk, Docker daemon), state that clearly and fix only what is fixable in-repo.

--- a/il_supermarket_parsers/parser_factory.py
+++ b/il_supermarket_parsers/parser_factory.py
@@ -16,6 +16,7 @@ class ParserFactory(Enum):
     GOOD_PHARM = all_parsers.GoodPharmFileConverter
     HAZI_HINAM = all_parsers.HaziHinamFileConverter
     HET_COHEN = all_parsers.HetChoenFileConverter
+    HET_COHEN_NEW_SOURCE = all_parsers.HetCohenNewFileConverter
     KESHET = all_parsers.KeshetFileConverter
     KING_STORE = all_parsers.KingStoreFileConverter
     MAAYAN_2000 = all_parsers.Maayan2000FileConverter

--- a/il_supermarket_parsers/parsers/__init__.py
+++ b/il_supermarket_parsers/parsers/__init__.py
@@ -9,6 +9,6 @@ from .salach_dabach import SalachDabachFileConverter
 from .shufersal import ShufersalFileConverter
 from .super_pharm import SuperPharmFileConverter
 from .victory import VictoryFileConverter, VictoryNewFileConverter
-from .het_cohen import HetChoenFileConverter
+from .het_cohen import HetChoenFileConverter, HetCohenNewFileConverter
 from .tiv_taam import TivTaamFileConverter
 from .other import *

--- a/il_supermarket_parsers/parsers/het_cohen.py
+++ b/il_supermarket_parsers/parsers/het_cohen.py
@@ -1,5 +1,9 @@
 from il_supermarket_parsers.engines import BigIdBranchesFileConverter
-from il_supermarket_parsers.documents import XmlDataFrameConverter
+from il_supermarket_parsers.documents import (
+    XmlDataFrameConverter,
+    SubRootedXmlDataFrameConverter,
+    SubRootedXmlOptions,
+)
 
 
 class HetChoenFileConverter(BigIdBranchesFileConverter):
@@ -23,5 +27,49 @@ class HetChoenFileConverter(BigIdBranchesFileConverter):
                 id_field="PromotionID",
                 roots=["ChainID", "SubChainID", "StoreID", "BikoretNo"],
                 date_columns=["PriceUpdateDate"],
+            ),
+        )
+
+
+class HetCohenNewFileConverter(BigIdBranchesFileConverter):
+    """ח. כהן - new source (laibcatalog API)"""
+
+    def __init__(self):
+        super().__init__(
+            stores_parser=SubRootedXmlDataFrameConverter(
+                list_key="SubChains",
+                id_field="StoreID",
+                options=SubRootedXmlOptions(
+                    roots=[
+                        "ChainID",
+                        "ChainName",
+                        "LastUpdateDate",
+                        "LastUpdateTime",
+                    ],
+                    sub_roots=["SubChainId", "SubChainName"],
+                    list_sub_key="Stores",
+                ),
+            ),
+            price_parser=XmlDataFrameConverter(
+                list_key="Items",
+                id_field="ItemCode",
+                roots=["ChainID", "SubChainID", "StoreID", "BikoretNo"],
+            ),
+            pricefull_parser=XmlDataFrameConverter(
+                list_key="Items",
+                id_field="ItemCode",
+                roots=["ChainID", "SubChainID", "StoreID", "BikoretNo"],
+            ),
+            promo_parser=XmlDataFrameConverter(
+                list_key="Promotions",
+                id_field="PromotionID",
+                roots=["ChainID", "SubChainID", "StoreID", "BikoretNo"],
+                date_columns=["PromotionUpdateTime"],
+            ),
+            promofull_parser=XmlDataFrameConverter(
+                list_key="Promotions",
+                id_field="PromotionID",
+                roots=["ChainID", "SubChainID", "StoreID", "BikoretNo"],
+                date_columns=["PromotionUpdateTime"],
             ),
         )

--- a/il_supermarket_parsers/parsers/tests/test_all.py
+++ b/il_supermarket_parsers/parsers/tests/test_all.py
@@ -84,6 +84,14 @@ class HetCohenTestCase(
     """
 
 
+class HetCohenNewSourceTestCase(
+    make_test_case(ScraperFactory.HET_COHEN_NEW_SOURCE, ParserFactory.HET_COHEN_NEW_SOURCE)
+):
+    """
+    Test case for Het Cohen New Source supermarket.
+    """
+
+
 class KeshetTestCase(make_test_case(ScraperFactory.KESHET, ParserFactory.KESHET)):
     """
     Test case for Keshet supermarket.
@@ -106,12 +114,12 @@ class Maayan2000TestCase(
     """
 
 
-class MahsaniAShukTestCase(
-    make_test_case(ScraperFactory.MAHSANI_ASHUK, ParserFactory.MAHSANI_ASHUK)
-):
-    """
-    Test case for Mahsani AShuk supermarket.
-    """
+# class MahsaniAShukTestCase(
+#     make_test_case(ScraperFactory.MAHSANI_ASHUK, ParserFactory.MAHSANI_ASHUK)
+# ):
+#     """
+#     Test case for Mahsani AShuk supermarket (old Matrix source; removed from ScraperFactory).
+#     """
 
 
 class MahsaniAShukNewSourceTestCase(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas>2.2.2
 pymongo==4.6.3
-il-supermarket-scraper>=1.0.2
+il-supermarket-scraper>=1.0.3
 tqdm>=4.66
 kafka-python>=2.0.2
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     tests_require=dev_required,
     extras_require={"test": ["pytest", "pytest-xdist", "pytest-asyncio"]},
     # *strongly* suggested for sharing
-    version="1.0.1",
+    version="1.0.2",
     # The license can be anything you like
     license="CUSTOM",
     description="python package that process the data dumped by the israeli supermarket",


### PR DESCRIPTION
- Add HetCohenNewFileConverter (laibcatalog API, same pattern as VictoryNew)
- Export from parsers/__init__.py
- Add ParserFactory.HET_COHEN_NEW_SOURCE entry
- Add HetCohenNewSourceTestCase to test_all.py
- Comment out MahsaniAShukTestCase (ScraperFactory.MAHSANI_ASHUK removed in scraper v1.0.3)
- Bump scraper requirement to >=1.0.3
- Bump parser version to 1.0.2