### PR TITLE
chore: bump parser version to 1.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     tests_require=dev_required,
     extras_require={"test": ["pytest", "pytest-xdist", "pytest-asyncio"]},
     # *strongly* suggested for sharing
-    version="1.0.2",
+    version="1.0.3",
     # The license can be anything you like
     license="CUSTOM",
     description="python package that process the data dumped by the israeli supermarket",


### PR DESCRIPTION
## Summary

Bump the parser package version from `1.0.2` to `1.0.3`.

## Reason

PR #43 added a backward-compatible fix for parsing Shufersal store files that
contain multiple `SubChain/Stores` sections.

A new patch version is required so the merged fix can be published and consumed
by downstream projects without changing the existing `v1.0.2` release.

## Changes

- Update the package version in `setup.py` from `1.0.2` to `1.0.3`.

## Verification

- Confirmed that `setup.py` declares exactly version `1.0.3`.
- This PR changes package metadata only; parser logic is unchanged.

## Related pull request

- #43