### PR TITLE
fix: make CSVOutputWriter column rewrite crash-safe

### DIFF
--- a/il_supermarket_parsers/utils/output_writers/csv_output_writer.py
+++ b/il_supermarket_parsers/utils/output_writers/csv_output_writer.py
@@ -60,6 +60,7 @@ class CSVOutputWriter(BaseOutputWriter):
     async def initialize(self) -> None:
         """Initialize the output writer"""
         if not self._initialized:
+            await asyncio.to_thread(self._cleanup_stale_temp)
             if self.exists():
                 self._existing_columns = await asyncio.to_thread(
                     self.get_existing_columns
@@ -168,20 +169,44 @@ class CSVOutputWriter(BaseOutputWriter):
         if not self._header_written:
             self._header_written = True
 
+    def _get_temp_path(self) -> str:
+        """Return the sibling temp file path used during column rewrites."""
+        return self.output_path.replace(".csv", "_temp.csv")
+
+    def _cleanup_stale_temp(self) -> None:
+        """Remove leftover temp file from a previous interrupted rewrite."""
+        temp_path = self._get_temp_path()
+        if os.path.exists(temp_path):
+            try:
+                os.remove(temp_path)
+                Logger.debug(f"Cleaned up stale temp file: {temp_path}")
+            except OSError:
+                pass
+
     def _append_columns_to_csv_sync(self, new_columns: List[str]) -> None:
-        """Add new columns (filled with sentinel) to an existing CSV file."""
-        output_file = self.output_path.replace(".csv", "_temp.csv")
-        with open(self.output_path, "r", encoding="utf-8") as infile, open(
-            output_file, "w+", newline="", encoding="utf-8"
-        ) as outfile:
-            reader = csv.reader(infile)
-            writer = csv.writer(outfile)
-            header = next(reader)
-            writer.writerow(header + new_columns)
-            for row in reader:
-                writer.writerow(row + [self.EMPTY_STRING] * len(new_columns))
-        os.remove(self.output_path)
-        os.rename(output_file, self.output_path)
+        """Add new columns (filled with sentinel) to an existing CSV file.
+
+        Uses atomic replace to avoid leaving temp files on crash/interrupt.
+        """
+        temp_path = self._get_temp_path()
+        try:
+            with open(self.output_path, "r", encoding="utf-8") as infile, open(
+                temp_path, "w", newline="", encoding="utf-8"
+            ) as outfile:
+                reader = csv.reader(infile)
+                writer = csv.writer(outfile)
+                header = next(reader)
+                writer.writerow(header + new_columns)
+                for row in reader:
+                    writer.writerow(row + [self.EMPTY_STRING] * len(new_columns))
+            os.replace(temp_path, self.output_path)
+        except BaseException:
+            if os.path.exists(temp_path):
+                try:
+                    os.remove(temp_path)
+                except OSError:
+                    pass
+            raise
 
     async def close(self) -> None:
         """Close the CSV file"""

--- a/il_supermarket_parsers/utils/output_writers/tests/test_csv_output_writer.py
+++ b/il_supermarket_parsers/utils/output_writers/tests/test_csv_output_writer.py
@@ -320,5 +320,96 @@ class TestCSVOutputWriter(unittest.IsolatedAsyncioTestCase):
         )
 
 
+    async def test_stale_temp_file_cleaned_on_init(self) -> None:
+        """Test that stale temp files from previous crashes are cleaned up on init."""
+        # Create a stale temp file
+        temp_path = self._csv_path().replace(".csv", "_temp.csv")
+        with open(temp_path, "w", encoding="utf-8") as f:
+            f.write("stale,data\n")
+        self.assertTrue(os.path.exists(temp_path))
+
+        writer = self._new_writer()
+        await writer.initialize()
+
+        # Temp file should be removed
+        self.assertFalse(os.path.exists(temp_path))
+
+    async def test_temp_file_cleaned_on_column_rewrite_exception(self) -> None:
+        """Test that temp file is cleaned up if column rewrite fails mid-write."""
+        # Create initial CSV
+        with open(self._csv_path(), "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(["a", "b"])
+            w.writerow(["1", "2"])
+
+        writer = self._new_writer()
+        await writer.initialize()
+
+        temp_path = writer._get_temp_path()
+
+        # Patch os.replace to simulate failure after temp file is written
+        original_replace = os.replace
+
+        def failing_replace(src, dst):
+            raise OSError("Simulated failure")
+
+        os.replace = failing_replace
+        try:
+            with self.assertRaises(OSError):
+                writer._append_columns_to_csv_sync(["c"])
+            # Temp file should be cleaned up even on failure
+            self.assertFalse(os.path.exists(temp_path))
+        finally:
+            os.replace = original_replace
+
+    async def test_no_temp_file_after_successful_column_rewrite(self) -> None:
+        """Test that no temp file remains after successful column rewrite."""
+        # Create initial CSV
+        with open(self._csv_path(), "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(["a", "b"])
+            w.writerow(["1", "2"])
+
+        writer = self._new_writer()
+        await writer.initialize()
+
+        temp_path = writer._get_temp_path()
+
+        writer._append_columns_to_csv_sync(["c"])
+
+        # No temp file should remain
+        self.assertFalse(os.path.exists(temp_path))
+        # Original file should exist with new columns
+        self.assertTrue(os.path.exists(self._csv_path()))
+        rows = read_data_rows(self._csv_path())
+        self.assertEqual(len(rows), 1)
+        self.assertIn("c", rows[0])
+
+    async def test_column_rewrite_atomic_replace(self) -> None:
+        """Test that column rewrite uses atomic replace (original content preserved on failure)."""
+        original_content = "a,b\n1,2\n"
+        with open(self._csv_path(), "w", encoding="utf-8") as f:
+            f.write(original_content)
+
+        writer = self._new_writer()
+        await writer.initialize()
+
+        # Patch os.replace to simulate failure
+        original_replace = os.replace
+
+        def failing_replace(src, dst):
+            raise OSError("Simulated failure")
+
+        os.replace = failing_replace
+        try:
+            with self.assertRaises(OSError):
+                writer._append_columns_to_csv_sync(["c"])
+            # Original file should be preserved
+            with open(self._csv_path(), "r", encoding="utf-8") as f:
+                self.assertEqual(f.read(), original_content)
+        finally:
+            os.replace = original_replace
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes the bug where `CSVOutputWriter._append_columns_to_csv_sync` leaves leftover `*_temp.csv` files when the process is interrupted mid-rewrite.

## Changes

### `csv_output_writer.py`
- **Atomic replacement**: Changed from `os.remove()` + `os.rename()` to `os.replace()` for atomic file replacement
- **Crash-safe cleanup**: Added `try/except` block to clean up temp file if any exception occurs during rewrite
- **Stale temp cleanup on init**: Added `_cleanup_stale_temp()` method that runs on `initialize()` to remove any leftover temp files from previous crashes
- **Helper method**: Added `_get_temp_path()` for consistent temp path computation

### `test_csv_output_writer.py`
Added 4 new unit tests:
- `test_stale_temp_file_cleaned_on_init`: Verifies leftover temp files are removed on initialization
- `test_temp_file_cleaned_on_column_rewrite_exception`: Verifies temp file cleanup when rewrite fails
- `test_no_temp_file_after_successful_column_rewrite`: Verifies no temp file remains after success
- `test_column_rewrite_atomic_replace`: Verifies original file is preserved if atomic replace fails

## Testing
- All 20 CSV output writer tests pass
- Pylint score: 10.00/10
- Broader test suite verified

## Checklist from Issue
- [x] Make column-rewrite crash-safe (no leftover temps)
- [x] Add a unit test that simulates interrupt / ensures temp cleanup
- [ ] Bump parsers version / release if fix ships (to be done on merge)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e28b6bb-b962-42d6-808b-6a7428c98d09?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e28b6bb-b962-42d6-808b-6a7428c98d09&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

