### PR TITLE
fix: skip weekly-release bump when setup.py is already ahead of latest tag

### DIFF
--- a/.github/scripts/weekly_release.sh
+++ b/.github/scripts/weekly_release.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Change-gate weekly release: noop if no commits since last v* tag; else bump setup.py patch, tag, release.
+# Change-gate weekly release: noop if no commits since last v* tag; else tag and release.
+# Bumps setup.py patch only when it still matches the latest v* tag (skip if already bumped).
 # Env: GITHUB_TOKEN (contents write), GITHUB_REPOSITORY
 # Outputs via GITHUB_OUTPUT when present: outcome=noop|released, version=...
 set -euo pipefail
@@ -27,7 +28,35 @@ if [ "${COMMIT_COUNT}" -eq 0 ]; then
   exit 0
 fi
 
-CURRENT=$(python - <<'PY'
+read -r SKIP_BUMP NEW_VERSION <<EOF
+$(python - <<PY
+import re
+from pathlib import Path
+
+def parse_version(v: str) -> tuple[int, ...]:
+    return tuple(int(x) for x in v.split("."))
+
+text = Path("setup.py").read_text(encoding="utf-8")
+match = re.search(r'version\s*=\s*"([^"]+)"', text)
+if not match:
+    raise SystemExit("version= not found in setup.py")
+current = match.group(1)
+tag_version = "${LATEST_TAG#v}" if "${LATEST_TAG:-}" else ""
+
+if tag_version and parse_version(current) > parse_version(tag_version):
+    print(f"yes {current}")
+else:
+    major, minor, patch = parse_version(current)
+    bumped = f"{major}.{minor}.{patch + 1}"
+    print(f"no {bumped}")
+PY
+)
+EOF
+
+if [ "${SKIP_BUMP}" = "yes" ]; then
+  echo "setup.py already at ${NEW_VERSION} (latest tag ${LATEST_TAG:-<none>}); skipping bump."
+else
+  CURRENT=$(python - <<'PY'
 import re, pathlib
 text = pathlib.Path("setup.py").read_text(encoding="utf-8")
 m = re.search(r'version\s*=\s*"([^"]+)"', text)
@@ -35,12 +64,10 @@ if not m:
     raise SystemExit("version= not found in setup.py")
 print(m.group(1))
 PY
-)
-IFS=. read -r MAJOR MINOR PATCH <<<"${CURRENT}"
-NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
-echo "Bumping setup.py ${CURRENT} -> ${NEW_VERSION}"
+  )
+  echo "Bumping setup.py ${CURRENT} -> ${NEW_VERSION}"
 
-python - <<PY
+  python - <<PY
 from pathlib import Path
 path = Path("setup.py")
 text = path.read_text(encoding="utf-8")
@@ -51,11 +78,13 @@ if old not in text:
 path.write_text(text.replace(old, new, 1), encoding="utf-8")
 PY
 
+  git add setup.py
+  git commit -m "chore: bump version to ${NEW_VERSION} [skip ci]"
+  git push origin HEAD:main
+fi
+
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-git add setup.py
-git commit -m "chore: bump version to ${NEW_VERSION} [skip ci]"
-git push origin HEAD:main
 
 TAG="v${NEW_VERSION}"
 git tag -a "${TAG}" -m "Release ${TAG}"


### PR DESCRIPTION
## Summary
- Weekly release now compares `setup.py` version to the latest `v*` tag before bumping.
- If `setup.py` is already ahead of the tag (e.g. maintainer bumped in a sync PR), the script tags and releases that version without a second patch bump.
- If versions still match, behavior is unchanged: patch-bump, commit, tag, and release.

## Test plan
- [ ] Review `weekly_release.sh` logic for `setup.py` == tag vs `setup.py` > tag
- [ ] Merge and optionally smoke-test via `gh workflow run weekly-release.yml --ref main` when commits exist since last tag

Made with [Cursor](https://cursor.com)