### PR TITLE
fix(super_pharm): parse current and legacy XML layouts for price, promo and stores

### DIFF
--- a/.cursor/rules/sre-agent.mdc
+++ b/.cursor/rules/sre-agent.mdc
@@ -64,6 +64,10 @@ For each failing test, apply the **fix-supermarket-parser** skill (`.cursor/skil
 | `element count mismatch` | Use `SubRootedXmlDataFrameConverter` or add wrapper to `ignore_column` |
 | `list_key element was not found` | `list_key` tag absent; check XML for actual wrapper tag |
 
+**Fixes must be backward compatible.** A chain adopting a new XML shape does not retire the old one — historical dumps still carry it. Never replace one hardcoded `list_key` with another; wrap both in `ConditionalXmlDataFrameConverter` (`check_key` = new wrapper, `option_b` = legacy) so the old shape keeps parsing. Cover every parser on the chain that could drift, not only the one that failed. See Step 4 of the fix-supermarket-parser skill.
+
+**A SKIPPED live-source test validated nothing.** Those tests skip when a chain's endpoint is unreachable or bot-protected. Prove the fix with a network-free test under `il_supermarket_parsers/tests/` exercising both shapes.
+
 ---
 
 ## Before marking any task complete

--- a/.cursor/skills/fix-supermarket-parser/SKILL.md
+++ b/.cursor/skills/fix-supermarket-parser/SKILL.md
@@ -21,8 +21,10 @@ Track progress with this checklist:
 - [ ] 1. Run the failing test and capture the error + file path
 - [ ] 2. Open the failing XML and identify list_key, id_field, roots
 - [ ] 3. Pick the correct converter from il_supermarket_parsers/documents
-- [ ] 4. Update the chain's parser class (parsers/<chain>.py) only
-- [ ] 5. Re-run that test, then the full chain test class
+- [ ] 4. Keep the OLD shape working too (see "Backward compatibility" below)
+- [ ] 5. Update the chain's parser class (parsers/<chain>.py) only
+- [ ] 6. Add an offline regression test covering BOTH shapes
+- [ ] 7. Re-run that test, then the full chain test class
 ```
 
 ### Step 1: Run the failing test
@@ -97,7 +99,35 @@ SubRootedXmlDataFrameConverter(
 )
 ```
 
-### Step 4: Change the chain's parser class only
+### Step 4: Backward compatibility (required)
+
+A chain changing its XML shape does **not** mean the old shape is gone. Historical dumps, slow-migrating branches, and re-published archives keep the previous wrapper around for a long time. Never swap one hardcoded `list_key` for another — that just trades a new bug for an old one, and it fails silently (zero rows, no error).
+
+Wrap both shapes in `ConditionalXmlDataFrameConverter`, with `check_key` set to the **new** wrapper so the legacy converter stays as the fallback:
+
+```python
+def _price_converter(list_key):
+    return XmlDataFrameConverter(
+        list_key=list_key,
+        id_field="ItemCode",
+        roots=["ChainId", "SubChainId", "StoreId", "BikoretNo"],
+    )
+
+
+price_parser = ConditionalXmlDataFrameConverter(
+    option_a=_price_converter("Items"),    # current shape
+    option_b=_price_converter("Details"),  # legacy shape, still parsed
+    check_key="Items",
+)
+```
+
+`check_key` is resolved per file at runtime: when the element exists `option_a` runs, otherwise `option_b`. That makes the change non-regressive — files parsing correctly today keep taking the exact same path.
+
+Apply this to **every** parser on the chain that could drift (`price`, `pricefull`, `promo`, `promofull`, `stores`), not only the one whose test failed. Adding the conditional to a parser that has not drifted yet costs nothing: when the new wrapper is absent, the legacy converter runs exactly as before.
+
+Precedents to copy: `parsers/shufersal.py` (stores: nested `SubChains` vs flat `STORES`) and `parsers/tiv_taam.py` (prices: `Items` vs `NewDataSet`). When a chain has three shapes, nest them — `option_b` accepts another `ConditionalXmlDataFrameConverter`.
+
+### Step 5: Change the chain's parser class only
 
 Edit only the file under `il_supermarket_parsers/parsers/<chain>.py`. Pass every parser you override into `super().__init__(...)` so the engine's `_get_parser` picks the updated instance (do NOT set attributes after `super().__init__()` — the base class stores promo under `self.promo_parsers`, and future subclasses may reassign in `__init__`, so constructor injection is the safe path).
 
@@ -142,12 +172,21 @@ Choose the base:
 - `BigIdBranchesFileConverter` — same, but store files are laid out as `Branches → Branch` (not `Stores → Store`).
 - `BaseFileConverter` — everything else (default casing `ChainId` / `StoreId`). Only use directly when no specialization fits.
 
-### Step 5: Re-run tests
+### Step 6: Add an offline regression test
+
+The live-source tests in `parsers/tests/test_all.py` **skip** when a chain's endpoint is unreachable or bot-protected, so they cannot be relied on to guard a parser. Add a network-free test under `il_supermarket_parsers/tests/` that feeds synthetic XML of **both** shapes through the real converter and asserts non-zero rows plus the expected ids.
+
+Copy the pattern from `il_supermarket_parsers/tests/test_super_pharm_layouts.py`.
+
+### Step 7: Re-run tests
 
 ```bash
 python -m pytest il_supermarket_parsers/parsers/tests/test_all.py::<ChainTestCase>::<test_name> -v
 python -m pytest il_supermarket_parsers/parsers/tests/test_all.py::<ChainTestCase> -v
+python -m pytest il_supermarket_parsers/tests/ -v
 ```
+
+A live-source test reporting SKIPPED means the source was unreachable — it did **not** validate your fix. The offline test from Step 6 is what proves the parser works.
 
 Then run `ReadLints` on the edited `parsers/<chain>.py`.
 
@@ -155,7 +194,7 @@ Then run `ReadLints` on the edited `parsers/<chain>.py`.
 
 | Error | Likely cause | Fix |
 |-------|--------------|-----|
-| `columns chainid missing from RangeIndex(start=0, stop=0, step=1)` (empty DataFrame, non-zero `tag_count`) | `list_key` not present in XML, so `_get_root` returns `None` and no rows are parsed | Change `list_key` to the element actually wrapping the rows |
+| `columns chainid missing from RangeIndex(start=0, stop=0, step=1)` (empty DataFrame, non-zero `tag_count`) | `list_key` not present in XML, so `_get_root` returns `None` and no rows are parsed | Add the wrapper the rows actually live under via `ConditionalXmlDataFrameConverter`, keeping the previous `list_key` as `option_b` (Step 4) |
 | `id <x> missing from <columns>` (DataFrame has rows) | Wrong `id_field` for this XML | Use the tag whose count equals `len(children of list_key)` |
 | `columns chainid missing` but DataFrame has rows | `roots` casing mismatch with the XML | Match case exactly (`ChainID` vs `ChainId`) |
 | `element count mismatch for '<tag>': XML has N, DataFrame has M` | Parser produced too few/many rows — usually nested repeats not flattened | Use `SubRootedXmlDataFrameConverter` or add the offending wrapper tag to `ignore_column` if it's metadata |
@@ -196,3 +235,12 @@ When you fix a supermarket parser, provide a quick report summarizing the struct
 
 Describe any changes in the mapping (e.g., list_key from 'Branches' to 'Stores', id_field casing, addition of roots, converter class changed).
 This helps future maintainers quickly see what was wrong and how it was addressed.
+
+Also state explicitly which shapes remain supported after the fix, e.g.:
+
+```
+price/pricefull: <Items> (current) | <Details> (legacy fallback)
+stores:          <SubChains>/<Stores> (current) | flat <Stores> (legacy fallback)
+```
+
+If you dropped support for a shape, say so and justify why it can no longer appear.

--- a/il_supermarket_parsers/parsers/super_pharm.py
+++ b/il_supermarket_parsers/parsers/super_pharm.py
@@ -6,7 +6,7 @@ from il_supermarket_parsers.documents import (
     ConditionalXmlDataFrameConverter,
 )
 
-_PRICE_ROOTS = ["ChainId", "SubChainId", "StoreId", "BikoretNo"]
+_ROW_ROOTS = ["ChainId", "SubChainId", "StoreId", "BikoretNo"]
 _STORE_ROOTS = ["ChainId", "ChainName", "LastUpdateDate", "LastUpdateTime"]
 
 
@@ -15,7 +15,7 @@ def _price_converter(list_key):
     return XmlDataFrameConverter(
         list_key=list_key,
         id_field="ItemCode",
-        roots=_PRICE_ROOTS,
+        roots=_ROW_ROOTS,
     )
 
 
@@ -24,26 +24,36 @@ def _promo_converter(list_key):
     return XmlDataFrameConverter(
         list_key=list_key,
         id_field="PromotionId",
-        roots=_PRICE_ROOTS,
+        roots=_ROW_ROOTS,
     )
+
+
+def _first_present(build_converter, list_keys):
+    """Chain converters so the first wrapper present in the file is the one used.
+
+    The final key is the fallback and is applied without a check, so a file whose
+    wrapper matches none of the candidates still goes through the historical
+    converter rather than yielding zero rows.
+    """
+    *candidates, fallback = list_keys
+    parser = build_converter(fallback)
+    for list_key in reversed(candidates):
+        parser = ConditionalXmlDataFrameConverter(
+            option_a=build_converter(list_key),
+            option_b=parser,
+            check_key=list_key,
+        )
+    return parser
 
 
 def _price_parser():
-    """Super-Pharm migrated price files to <Items>; older dumps still use <Details>."""
-    return ConditionalXmlDataFrameConverter(
-        option_a=_price_converter("Items"),
-        option_b=_price_converter("Details"),
-        check_key="Items",
-    )
+    """<Items> is the shape Super-Pharm publishes now; older dumps used <Details>."""
+    return _first_present(_price_converter, ["Items", "Products", "Details"])
 
 
 def _promo_parser():
-    """Super-Pharm promo files may ship as <Promotions> or legacy <Details>."""
-    return ConditionalXmlDataFrameConverter(
-        option_a=_promo_converter("Promotions"),
-        option_b=_promo_converter("Details"),
-        check_key="Promotions",
-    )
+    """<Promotions> is the standard shape; older dumps used <Details>."""
+    return _first_present(_promo_converter, ["Promotions", "Sales", "Details"])
 
 
 def _stores_parser():

--- a/il_supermarket_parsers/parsers/super_pharm.py
+++ b/il_supermarket_parsers/parsers/super_pharm.py
@@ -3,7 +3,46 @@ from il_supermarket_parsers.documents import (
     XmlDataFrameConverter,
     SubRootedXmlDataFrameConverter,
     SubRootedXmlOptions,
+    ConditionalXmlDataFrameConverter,
 )
+
+_PRICE_ROOTS = ["ChainId", "SubChainId", "StoreId", "BikoretNo"]
+
+
+def _price_converter(list_key):
+    """price/pricefull converter for a given row wrapper"""
+    return XmlDataFrameConverter(
+        list_key=list_key,
+        id_field="ItemCode",
+        roots=_PRICE_ROOTS,
+    )
+
+
+def _promo_converter(list_key):
+    """promo/promofull converter for a given row wrapper"""
+    return XmlDataFrameConverter(
+        list_key=list_key,
+        id_field="PromotionId",
+        roots=_PRICE_ROOTS,
+    )
+
+
+def _price_parser():
+    """Super-Pharm migrated price files to <Items>; older dumps still use <Details>."""
+    return ConditionalXmlDataFrameConverter(
+        option_a=_price_converter("Items"),
+        option_b=_price_converter("Details"),
+        check_key="Items",
+    )
+
+
+def _promo_parser():
+    """Super-Pharm promo files may ship as <Promotions> or legacy <Details>."""
+    return ConditionalXmlDataFrameConverter(
+        option_a=_promo_converter("Promotions"),
+        option_b=_promo_converter("Details"),
+        check_key="Promotions",
+    )
 
 
 class SuperPharmFileConverter(BigIDFileConverter):
@@ -11,26 +50,10 @@ class SuperPharmFileConverter(BigIDFileConverter):
 
     def __init__(self):
         super().__init__(
-            promofull_parser=XmlDataFrameConverter(
-                list_key="Details",
-                id_field="PromotionId",
-                roots=["ChainId", "SubChainId", "StoreId", "BikoretNo"],
-            ),
-            promo_parser=XmlDataFrameConverter(
-                list_key="Details",
-                id_field="PromotionId",
-                roots=["ChainId", "SubChainId", "StoreId", "BikoretNo"],
-            ),
-            pricefull_parser=XmlDataFrameConverter(
-                list_key="Items",
-                id_field="ItemCode",
-                roots=["ChainId", "SubChainId", "StoreId", "BikoretNo"],
-            ),
-            price_parser=XmlDataFrameConverter(
-                list_key="Items",
-                id_field="ItemCode",
-                roots=["ChainId", "SubChainId", "StoreId", "BikoretNo"],
-            ),
+            promofull_parser=_promo_parser(),
+            promo_parser=_promo_parser(),
+            pricefull_parser=_price_parser(),
+            price_parser=_price_parser(),
             stores_parser=SubRootedXmlDataFrameConverter(
                 list_key="SubChains",
                 id_field="StoreID",

--- a/il_supermarket_parsers/parsers/super_pharm.py
+++ b/il_supermarket_parsers/parsers/super_pharm.py
@@ -22,12 +22,12 @@ class SuperPharmFileConverter(BigIDFileConverter):
                 roots=["ChainId", "SubChainId", "StoreId", "BikoretNo"],
             ),
             pricefull_parser=XmlDataFrameConverter(
-                list_key="Details",
+                list_key="Items",
                 id_field="ItemCode",
                 roots=["ChainId", "SubChainId", "StoreId", "BikoretNo"],
             ),
             price_parser=XmlDataFrameConverter(
-                list_key="Details",
+                list_key="Items",
                 id_field="ItemCode",
                 roots=["ChainId", "SubChainId", "StoreId", "BikoretNo"],
             ),

--- a/il_supermarket_parsers/parsers/super_pharm.py
+++ b/il_supermarket_parsers/parsers/super_pharm.py
@@ -7,6 +7,7 @@ from il_supermarket_parsers.documents import (
 )
 
 _PRICE_ROOTS = ["ChainId", "SubChainId", "StoreId", "BikoretNo"]
+_STORE_ROOTS = ["ChainId", "ChainName", "LastUpdateDate", "LastUpdateTime"]
 
 
 def _price_converter(list_key):
@@ -45,6 +46,27 @@ def _promo_parser():
     )
 
 
+def _stores_parser():
+    """Super-Pharm nests stores under <SubChains>; flat <Stores> dumps stay readable."""
+    return ConditionalXmlDataFrameConverter(
+        option_a=SubRootedXmlDataFrameConverter(
+            list_key="SubChains",
+            id_field="StoreID",
+            options=SubRootedXmlOptions(
+                list_sub_key="Stores",
+                sub_roots=["SubChainID", "SubChainName"],
+                roots=_STORE_ROOTS,
+            ),
+        ),
+        option_b=XmlDataFrameConverter(
+            list_key="Stores",
+            id_field="StoreID",
+            roots=_STORE_ROOTS,
+        ),
+        check_key="SubChains",
+    )
+
+
 class SuperPharmFileConverter(BigIDFileConverter):
     """סופר פארם"""
 
@@ -54,13 +76,5 @@ class SuperPharmFileConverter(BigIDFileConverter):
             promo_parser=_promo_parser(),
             pricefull_parser=_price_parser(),
             price_parser=_price_parser(),
-            stores_parser=SubRootedXmlDataFrameConverter(
-                list_key="SubChains",
-                id_field="StoreID",
-                options=SubRootedXmlOptions(
-                    list_sub_key="Stores",
-                    sub_roots=["SubChainID", "SubChainName"],
-                    roots=["ChainId", "ChainName", "LastUpdateDate", "LastUpdateTime"],
-                ),
-            ),
+            stores_parser=_stores_parser(),
         )

--- a/il_supermarket_parsers/parsers/tests/test_case.py
+++ b/il_supermarket_parsers/parsers/tests/test_case.py
@@ -89,7 +89,7 @@ async def _process_files(
     return dfs
 
 
-def make_test_case(scraper_enum, parser_enum):
+def make_test_case(scraper_enum, parser_enum):  # pylint: disable=R0915
     """create test suite for parser"""
 
     class TestParser(unittest.TestCase):
@@ -189,8 +189,16 @@ def make_test_case(scraper_enum, parser_enum):
             ):
                 files.append(file)
 
-            # assert len(files) > 0, f"No files found in {sub_folder}"
             _validate_file_loading(files, sub_folder)
+
+            # Ensure we actually downloaded and processed files for enabled scrapers
+            # Without this check, tests pass vacuously when scraper fails to download
+            if ScraperFactory.is_scraper_enabled(self.scraper_enum) and len(files) == 0:
+                self.skipTest(
+                    f"No files downloaded for enabled scraper {self.parser_name}. "
+                    f"Source may be unavailable or blocked."
+                )
+
             await _process_files(files, parser)
 
             # self._make_sure_status_file_is_valid(sub_folder)

--- a/il_supermarket_parsers/tests/test_super_pharm_layouts.py
+++ b/il_supermarket_parsers/tests/test_super_pharm_layouts.py
@@ -2,7 +2,9 @@
 
 Super-Pharm migrated price files from the legacy ``<Details>`` wrapper to the
 standard ``<Items>`` layout. Both shapes must keep parsing, because historical
-dumps still use the legacy wrapper.
+dumps still use the legacy wrapper. The same applies to promo files
+(``<Promotions>`` vs ``<Details>``) and store files (stores nested under
+``<SubChains>`` vs a flat ``<Stores>`` list).
 
 These tests run without network access, so they still guard the parser when the
 live-source tests in ``parsers/tests/test_all.py`` skip due to an unreachable
@@ -94,6 +96,53 @@ PROMO_DETAILS_XML = """\
 """
 
 
+STORE_SUBCHAINS_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<Root>
+  <ChainId>7290172900007</ChainId>
+  <ChainName>Super-Pharm</ChainName>
+  <LastUpdateDate>2026-08-27</LastUpdateDate>
+  <LastUpdateTime>10:00</LastUpdateTime>
+  <SubChains>
+    <SubChain>
+      <SubChainID>001</SubChainID>
+      <SubChainName>Main</SubChainName>
+      <Stores>
+        <Store>
+          <StoreID>001</StoreID>
+          <StoreName>Tel Aviv</StoreName>
+        </Store>
+        <Store>
+          <StoreID>002</StoreID>
+          <StoreName>Haifa</StoreName>
+        </Store>
+      </Stores>
+    </SubChain>
+  </SubChains>
+</Root>
+"""
+
+STORE_FLAT_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<Root>
+  <ChainId>7290172900007</ChainId>
+  <ChainName>Super-Pharm</ChainName>
+  <LastUpdateDate>2026-08-27</LastUpdateDate>
+  <LastUpdateTime>10:00</LastUpdateTime>
+  <Stores>
+    <Store>
+      <StoreID>003</StoreID>
+      <StoreName>Eilat</StoreName>
+    </Store>
+    <Store>
+      <StoreID>004</StoreID>
+      <StoreName>Beer Sheva</StoreName>
+    </Store>
+  </Stores>
+</Root>
+"""
+
+
 async def _read_rows(folder, file_name):
     """Parse one file with the Super-Pharm converter and return the rows."""
     dump_file = file_name_to_components(folder, file_name)
@@ -152,6 +201,17 @@ class SuperPharmLayoutTestCase(unittest.TestCase):
         """Promo using the legacy <Details> wrapper still yields rows."""
         rows = _parse("Promo7290172900007-000-202608260000.xml", PROMO_DETAILS_XML)
         self._assert_ids(rows, ["4001"], "promotionid")
+
+    def test_stores_subchains_layout(self):
+        """Stores nested under <SubChains> yield rows carrying the sub-chain header."""
+        rows = _parse("Stores7290172900007-000-202608270000.xml", STORE_SUBCHAINS_XML)
+        self._assert_ids(rows, ["001", "002"], "storeid")
+        self.assertEqual([row["subchainid"] for row in rows], ["001", "001"])
+
+    def test_stores_flat_layout(self):
+        """A flat <Stores> list without the <SubChains> wrapper still yields rows."""
+        rows = _parse("Stores7290172900007-000-202608270000.xml", STORE_FLAT_XML)
+        self._assert_ids(rows, ["003", "004"], "storeid")
 
     def test_price_roots_are_promoted_to_columns(self):
         """Header fields are attached to rows in both layouts."""

--- a/il_supermarket_parsers/tests/test_super_pharm_layouts.py
+++ b/il_supermarket_parsers/tests/test_super_pharm_layouts.py
@@ -63,6 +63,39 @@ PRICE_DETAILS_XML = """\
 </Root>
 """
 
+PRICE_PRODUCTS_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<Root>
+  <ChainId>7290172900007</ChainId>
+  <SubChainId>000</SubChainId>
+  <StoreId>667</StoreId>
+  <BikoretNo>0</BikoretNo>
+  <Products>
+    <Product>
+      <ItemCode>5001</ItemCode>
+      <ItemName>Sunscreen</ItemName>
+      <ItemPrice>39.90</ItemPrice>
+    </Product>
+  </Products>
+</Root>
+"""
+
+PROMO_SALES_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<Root>
+  <ChainId>7290172900007</ChainId>
+  <SubChainId>000</SubChainId>
+  <StoreId>667</StoreId>
+  <BikoretNo>0</BikoretNo>
+  <Sales>
+    <Sale>
+      <PromotionId>6001</PromotionId>
+      <PromotionDescription>Bundle deal</PromotionDescription>
+    </Sale>
+  </Sales>
+</Root>
+"""
+
 PROMO_PROMOTIONS_XML = """\
 <?xml version="1.0" encoding="utf-8"?>
 <Root>
@@ -184,6 +217,16 @@ class SuperPharmLayoutTestCase(unittest.TestCase):
         """Price using the legacy <Details> wrapper still yields rows."""
         rows = _parse("Price7290172900007-000-202608260000.xml", PRICE_DETAILS_XML)
         self._assert_ids(rows, ["2001", "2002"], "itemcode")
+
+    def test_pricefull_products_layout(self):
+        """PriceFull using the BigID <Products> wrapper yields rows."""
+        rows = _parse("PriceFull7290172900007-000-202608260000.xml", PRICE_PRODUCTS_XML)
+        self._assert_ids(rows, ["5001"], "itemcode")
+
+    def test_promofull_sales_layout(self):
+        """PromoFull using the BigID <Sales> wrapper yields rows."""
+        rows = _parse("PromoFull7290172900007-000-202608260000.xml", PROMO_SALES_XML)
+        self._assert_ids(rows, ["6001"], "promotionid")
 
     def test_promofull_promotions_layout(self):
         """PromoFull using the standard <Promotions> wrapper yields rows."""

--- a/il_supermarket_parsers/tests/test_super_pharm_layouts.py
+++ b/il_supermarket_parsers/tests/test_super_pharm_layouts.py
@@ -1,0 +1,165 @@
+"""Offline regression tests for Super-Pharm XML layout drift.
+
+Super-Pharm migrated price files from the legacy ``<Details>`` wrapper to the
+standard ``<Items>`` layout. Both shapes must keep parsing, because historical
+dumps still use the legacy wrapper.
+
+These tests run without network access, so they still guard the parser when the
+live-source tests in ``parsers/tests/test_all.py`` skip due to an unreachable
+Super-Pharm endpoint.
+"""
+
+import asyncio
+import os
+import tempfile
+import unittest
+
+from il_supermarket_parsers.parsers.super_pharm import SuperPharmFileConverter
+from il_supermarket_parsers.utils.loading_utils import file_name_to_components
+
+PRICE_ITEMS_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<Root>
+  <ChainId>7290172900007</ChainId>
+  <SubChainId>000</SubChainId>
+  <StoreId>667</StoreId>
+  <BikoretNo>0</BikoretNo>
+  <Items>
+    <Item>
+      <ItemCode>1001</ItemCode>
+      <ItemName>Shampoo</ItemName>
+      <ItemPrice>19.90</ItemPrice>
+    </Item>
+    <Item>
+      <ItemCode>1002</ItemCode>
+      <ItemName>Toothpaste</ItemName>
+      <ItemPrice>12.50</ItemPrice>
+    </Item>
+  </Items>
+</Root>
+"""
+
+PRICE_DETAILS_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<Root>
+  <ChainId>7290172900007</ChainId>
+  <SubChainId>000</SubChainId>
+  <StoreId>667</StoreId>
+  <BikoretNo>0</BikoretNo>
+  <Details>
+    <Line>
+      <ItemCode>2001</ItemCode>
+      <ItemName>Soap</ItemName>
+      <ItemPrice>8.90</ItemPrice>
+    </Line>
+    <Line>
+      <ItemCode>2002</ItemCode>
+      <ItemName>Vitamins</ItemName>
+      <ItemPrice>45.00</ItemPrice>
+    </Line>
+  </Details>
+</Root>
+"""
+
+PROMO_PROMOTIONS_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<Root>
+  <ChainId>7290172900007</ChainId>
+  <SubChainId>000</SubChainId>
+  <StoreId>667</StoreId>
+  <BikoretNo>0</BikoretNo>
+  <Promotions>
+    <Promotion>
+      <PromotionId>3001</PromotionId>
+      <PromotionDescription>Two for one</PromotionDescription>
+    </Promotion>
+  </Promotions>
+</Root>
+"""
+
+PROMO_DETAILS_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<Root>
+  <ChainId>7290172900007</ChainId>
+  <SubChainId>000</SubChainId>
+  <StoreId>667</StoreId>
+  <BikoretNo>0</BikoretNo>
+  <Details>
+    <Line>
+      <PromotionId>4001</PromotionId>
+      <PromotionDescription>Half price</PromotionDescription>
+    </Line>
+  </Details>
+</Root>
+"""
+
+
+async def _read_rows(folder, file_name):
+    """Parse one file with the Super-Pharm converter and return the rows."""
+    dump_file = file_name_to_components(folder, file_name)
+    parser = SuperPharmFileConverter()
+    return [row async for row in parser.read(dump_file)]
+
+
+def _parse(file_name, content):
+    """Write content to a temp folder and parse it."""
+    with tempfile.TemporaryDirectory() as folder:
+        with open(os.path.join(folder, file_name), "w", encoding="utf-8") as handle:
+            handle.write(content)
+        return asyncio.run(_read_rows(folder, file_name))
+
+
+class SuperPharmLayoutTestCase(unittest.TestCase):
+    """Both the current and legacy Super-Pharm layouts must parse."""
+
+    def _assert_ids(self, rows, expected_ids, id_column):
+        self.assertEqual(len(rows), len(expected_ids))
+        self.assertEqual([row[id_column] for row in rows], expected_ids)
+
+    def test_pricefull_items_layout(self):
+        """PriceFull using the standard <Items> wrapper yields rows."""
+        rows = _parse("PriceFull7290172900007-000-202608260000.xml", PRICE_ITEMS_XML)
+        self._assert_ids(rows, ["1001", "1002"], "itemcode")
+
+    def test_pricefull_legacy_details_layout(self):
+        """PriceFull using the legacy <Details> wrapper still yields rows."""
+        rows = _parse("PriceFull7290172900007-000-202608260000.xml", PRICE_DETAILS_XML)
+        self._assert_ids(rows, ["2001", "2002"], "itemcode")
+
+    def test_price_items_layout(self):
+        """Price using the standard <Items> wrapper yields rows."""
+        rows = _parse("Price7290172900007-000-202608260000.xml", PRICE_ITEMS_XML)
+        self._assert_ids(rows, ["1001", "1002"], "itemcode")
+
+    def test_price_legacy_details_layout(self):
+        """Price using the legacy <Details> wrapper still yields rows."""
+        rows = _parse("Price7290172900007-000-202608260000.xml", PRICE_DETAILS_XML)
+        self._assert_ids(rows, ["2001", "2002"], "itemcode")
+
+    def test_promofull_promotions_layout(self):
+        """PromoFull using the standard <Promotions> wrapper yields rows."""
+        rows = _parse(
+            "PromoFull7290172900007-000-202608260000.xml", PROMO_PROMOTIONS_XML
+        )
+        self._assert_ids(rows, ["3001"], "promotionid")
+
+    def test_promofull_legacy_details_layout(self):
+        """PromoFull using the legacy <Details> wrapper still yields rows."""
+        rows = _parse("PromoFull7290172900007-000-202608260000.xml", PROMO_DETAILS_XML)
+        self._assert_ids(rows, ["4001"], "promotionid")
+
+    def test_promo_legacy_details_layout(self):
+        """Promo using the legacy <Details> wrapper still yields rows."""
+        rows = _parse("Promo7290172900007-000-202608260000.xml", PROMO_DETAILS_XML)
+        self._assert_ids(rows, ["4001"], "promotionid")
+
+    def test_price_roots_are_promoted_to_columns(self):
+        """Header fields are attached to rows in both layouts."""
+        for content in (PRICE_ITEMS_XML, PRICE_DETAILS_XML):
+            rows = _parse("PriceFull7290172900007-000-202608260000.xml", content)
+            self.assertEqual(rows[0]["chainid"], "7290172900007")
+            self.assertEqual(rows[0]["storeid"], "667")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes #65

Super-Pharm price files parse to 0 rows because the parser still expects the legacy `<Details>` wrapper while the chain migrated to the standard `<Items>`/`<Item>` layout.

Rather than swapping one hardcoded wrapper for another (which would break historical dumps still using `<Details>`), the wrapper is now resolved **per file at runtime**, so every known shape parses.

## Changes

### 1. Backward-compatible Super-Pharm parser (`parsers/super_pharm.py`)

`_first_present()` nests `ConditionalXmlDataFrameConverter` so the first wrapper actually present in the file wins. The trailing key is an unchecked fallback, so a file matching none of the candidates still goes through the historical converter instead of yielding zero rows.

| File type | Resolution order |
|---|---|
| `price` / `pricefull` | `<Items>` → `<Products>` → `<Details>` |
| `promo` / `promofull` | `<Promotions>` → `<Sales>` → `<Details>` |
| `stores` | `<SubChains>`/`<Stores>` → flat `<Stores>` |

`<Items>` is the confirmed current price shape and `<Details>` the historical one. `<Products>`/`<Sales>` are the defaults of `BigIDFileConverter`, the engine this chain extends, and `<Promotions>` is the standard gov shape — all included pre-emptively.

This is **non-regressive and cheap**: a file carrying the current wrapper matches on the first check and takes exactly the path it takes today, so extra candidates cost nothing on the common path.

Measured across every shape:

```
file type  wrapper                   rows  status
-------------------------------------------------------
PriceFull  <Items>      (current)       2  OK      <-- was 0 before the fix
PriceFull  <Products>   (BigID)         1  OK
PriceFull  <Details>    (legacy)        2  OK      <-- unchanged
Price      <Items>      (current)       2  OK      <-- was 0 before the fix
Price      <Details>    (legacy)        2  OK      <-- unchanged
PromoFull  <Promotions> (standard)      1  OK
PromoFull  <Sales>      (BigID)         1  OK
PromoFull  <Details>    (legacy)        1  OK      <-- unchanged
Promo      <Promotions> (standard)      1  OK
Promo      <Details>    (legacy)        1  OK      <-- unchanged
Stores     <SubChains>  (current)       2  OK      <-- unchanged
Stores     flat <Stores>(legacy)        2  OK      <-- was 0 before the fix
```

Also renamed `_PRICE_ROOTS` to `_ROW_ROOTS`, since the promo converter shares it.

### 2. Why CI never caught this (`parsers/tests/test_case.py`)

The assertion guarding against an empty download was commented out:

```python
# assert len(files) > 0, f"No files found in {sub_folder}"
```

Super-Pharm's endpoint returns HTTP 247 (bot protection), so the scraper downloaded **zero** files. With no files, the per-file validation loop never executed and the test reported PASSED without parsing anything — the parser bug was invisible.

Tests now distinguish the three outcomes:

- **PASSED** — files downloaded and parsed correctly
- **SKIPPED** — source unavailable/blocked (no silent pass)
- **FAILED** — files downloaded but parser produced 0 rows

### 3. Offline regression test (`tests/test_super_pharm_layouts.py`)

Because the live-source test skips whenever Super-Pharm is blocked, it cannot guard this parser. Added 12 network-free tests over synthetic XML covering every wrapper above. These run in CI regardless of source availability.

### 4. Agent instructions updated (`.cursor/`)

Per review feedback, so future parser work defaults to backward compatibility rather than needing to be asked:

- **`skills/fix-supermarket-parser/SKILL.md`** — new Step 4 "Backward compatibility (required)" with the `ConditionalXmlDataFrameConverter` recipe and precedents, plus instruction to cover *every* parser on the chain that could drift and to nest conditionals when a chain has three shapes. New Step 6 requires an offline regression test over both shapes. Error table and report template name both shapes.
- **`rules/sre-agent.mdc`** — backward compatibility is mandatory when fixing a parser, and a SKIPPED live-source test validated nothing.

## Testing

- Full suite: **158 passed, 126 skipped, 0 failed** (skips are chains whose endpoints are unreachable from CI; the pass/skip split shifts run to run with source availability)
- Offline layout tests: 12 passed
- Pylint: 10.00/10
- Formatted with `black`

## Caveat

Super-Pharm's endpoint returned HTTP 247 on every attempt from this environment, so `<Items>` is confirmed against the XML sample in #65 rather than a freshly downloaded file, and the `<Products>`/`<Sales>`/flat-`<Stores>` fallbacks are inferred from the engine defaults and the `shufersal.py` precedent rather than observed dumps. All of them sit behind checks, so a wrong guess cannot affect files that parse correctly today.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1969201-051b-4293-ad4d-37990a885e48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1969201-051b-4293-ad4d-37990a885e48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

