### PR TITLE
fix(ci): open failure issues only on scheduled/manual runs

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -78,7 +78,12 @@ jobs:
     # Always open an issue when pytest failed. Do not use failure() alone:
     # continue-on-error used to mark the pytest step successful, so the
     # build job stayed green and this job was skipped.
-    if: always() && needs.build.result != 'cancelled' && needs.build.outputs.pytest_failed == 'true'
+    if: >
+      always()
+      && needs.build.result != 'cancelled'
+      && needs.build.outputs.pytest_failed == 'true'
+      && github.event_name != 'pull_request'
+      && github.event_name != 'push'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## Summary
- Detect pytest failure from step `outcome` (not `conclusion`) and from `FAILED`/`ERROR` lines in the log, then still fail the build job.
- Open a CI issue (and maintainer webhook) when pytest fails, but **not** on `pull_request` or `push` — only `schedule` / `workflow_dispatch`.
- Also includes crash-safe CSV column rewrite (no leftover temp files) that is on this branch vs `main`.

## Test plan
- [ ] Confirm a PR/push run with failing tests does **not** open a GitHub issue
- [ ] Confirm a scheduled or `workflow_dispatch` run with failing tests **does** open (or comment on) a deduped issue
- [ ] Confirm a cancelled build still skips issue creation
- [ ] Confirm weekend weekly-release still only runs when the test job succeeds on schedule


Made with [Cursor](https://cursor.com)