### PR TITLE
Use active_folder_names() to filter deprecated chains

### DIFF
--- a/il_supermarket_parsers/utils/data_loaders/data_loader.py
+++ b/il_supermarket_parsers/utils/data_loaders/data_loader.py
@@ -25,7 +25,7 @@ class DataLoader(BaseDataLoader):
         """load details about the files in the folder as async generator"""
 
         resolved_stores = (
-            enabled_scraper if enabled_scraper else DumpFolderNames.all_folders_names()
+            enabled_scraper if enabled_scraper else DumpFolderNames.active_folder_names()
         )
         resolved_types = files_types if files_types else FileTypesFilters.all_types()
         files_types_set: Set[str] = (

--- a/il_supermarket_parsers/utils/data_loaders/tests/test_data_loader.py
+++ b/il_supermarket_parsers/utils/data_loaders/tests/test_data_loader.py
@@ -140,7 +140,7 @@ class TestDataLoaderStoreFilter(unittest.IsolatedAsyncioTestCase):
         self._tmp = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
         self.root = self._tmp.name
         self.store_a_dir = _make_store_dir(self.root, DumpFolderNames.BAREKET.value)
-        self.store_b_dir = _make_store_dir(self.root, DumpFolderNames.COFIX.value)
+        self.store_b_dir = _make_store_dir(self.root, DumpFolderNames.SHUFERSAL.value)
         _touch(self.store_a_dir, "PriceFull7290000000000-001-20250101.xml")
         _touch(self.store_b_dir, "PriceFull7290000000000-001-20250101.xml")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Uses `DumpFolderNames.active_folder_names()` instead of `all_folders_names()` in the DataLoader to automatically filter out deprecated chains (Victory, HetCohen, MahsaniAShuk, etc.).

## Changes

- **`data_loader.py`**: Changed the fallback from `all_folders_names()` to `active_folder_names()` when no explicit `enabled_scraper` list is provided
- **`test_data_loader.py`**: Updated test to use `SHUFERSAL` instead of `COFIX` (which is now deprecated)

## Impact

This eliminates the permanent no-op status entries for deprecated chains by using the scraper package's built-in `active_folder_names()` method, which already knows which chains are active.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f52d0d4-f933-4031-9aa4-b40027d09be9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f52d0d4-f933-4031-9aa4-b40027d09be9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

