### PR TITLE
Use GitHub App tokens and pin CI to the ci runner

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -15,33 +15,10 @@ permissions:
 
 jobs:
   build:
-    runs-on:
-      - self-hosted
-      - ci
-
+    runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Free disk space
+    - uses: actions/checkout@v3
+    - name: Build and run lint Docker stage
       run: |
-        df --human-readable
-        docker 2>/dev/null 1>&2 rmi $(docker image ls --all --quiet) || true
-        rm --recursive --force "$AGENT_TOOLSDIRECTORY"
-        df --human-readable
-
-    - name: Build with Docker
-      run: docker build -t erlichsefi/israeli-supermarket-parsers:lint --target lint .
-
-    - name: Remove legacy pylint container name
-      run: docker rm -f parsers-pylint-runner 2>/dev/null || true
-
-    - name: Analysing the code with pylint
-      run: |
-        mkdir -p temp
-        set -o pipefail
-        docker run --rm -v ./temp:/usr/src/app/temp --name parsers-pylint-runner erlichsefi/israeli-supermarket-parsers:lint 2>&1 | tee pylint-log.txt
-
-    - name: Docker builder prune
-      if: always()
-      run: docker builder prune -f
+        docker build --target lint -t erlichsefi/israeli-supermarket-parsers:lint .
+        docker run --rm erlichsefi/israeli-supermarket-parsers:lint

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -15,7 +15,9 @@ permissions:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - ci
 
     steps:
     - name: Checkout

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -18,7 +18,9 @@ permissions:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - ci
     outputs:
       pytest_failed: ${{ steps.test_result.outputs.failed }}
     steps:


### PR DESCRIPTION
## Summary
- Mint a GitHub App installation token for weekly release, coordinator ping, and daily-publish deps issues so protected-main checkout no longer depends on expiring PATs (PAT secrets remain as fallback).
- Pin pytest to `[self-hosted, ci]` so it cannot land on the production scrape machine.
- Run pylint on GitHub-hosted `ubuntu-latest`.

## Test plan
- [ ] Confirm org `APP_CLIENT_ID` / `APP_PRIVATE_KEY` and that the App is installed on scrapers, parsers, and daily-publish
- [ ] Confirm the CI self-hosted runner has the `ci` label
- [ ] After merge, `gh workflow run weekly-release.yml --ref main` (or wait for weekend) and check checkout + coordinator signal use the App token
- [ ] Confirm a PR test-suite run is picked up by the `ci` runner, not production
- [ ] Confirm pylint runs on `ubuntu-latest`