### PR TITLE
Add fail-fast is-parsing-complete skill

### DIFF
--- a/.cursor/agents/maintainer.md
+++ b/.cursor/agents/maintainer.md
@@ -14,7 +14,7 @@ You are the project maintainer for this codebase. Your job is to keep CI green, 
 When invoked:
 
 1. **Read CI truth**: Inspect `.github/workflows/` (especially `test-suite.yml`, `pylint.yml`) to see exactly what runs in CI. Prefer reproducing those steps locally before editing code.
-2. **Tests**: Match `test-suite.yml`: build the Docker image with `--target test` and run the container (`docker build` / `docker run`, or local `pytest` if Docker is unavailable). Follow the **run-pytest** skill (`.cursor/skills/run-pytest/SKILL.md`).
+2. **Tests**: Match `test-suite.yml`: build the Docker image with `--target test` and run the container (`docker build` / `docker run`, or local `pytest` if Docker is unavailable). Follow the **run-pytest** skill (`.cursor/skills/run-pytest/SKILL.md`). Pytest sampling (`NUM_SAMPLES=10`) and SKIPPED live tests do not prove completeness — use **is-parsing-complete** (`.cursor/skills/is-parsing-complete/SKILL.md`) to fail-fast parse every file.
 3. **Lint**: Match `pylint.yml`: run pylint on tracked `*.py` files with the same `--disable` flags as the workflow. Follow the **run-pylint** skill (`.cursor/skills/run-pylint/SKILL.md`).
 4. **Fixes**: Fix failures with the smallest diff that addresses the root cause. Do not refactor unrelated code. To fix XML format drift, follow the **fix-supermarket-parser** skill (`.cursor/skills/fix-supermarket-parser/SKILL.md`).
 5. **Workflow / Docker**: Fix `.github` or `Dockerfile` only as needed for the specific failure; avoid churning unrelated workflow files.

--- a/.cursor/skills/fix-supermarket-parser/SKILL.md
+++ b/.cursor/skills/fix-supermarket-parser/SKILL.md
@@ -186,7 +186,7 @@ python -m pytest il_supermarket_parsers/parsers/tests/test_all.py::<ChainTestCas
 python -m pytest il_supermarket_parsers/tests/ -v
 ```
 
-A live-source test reporting SKIPPED means the source was unreachable — it did **not** validate your fix. The offline test from Step 6 is what proves the parser works.
+A live-source test reporting SKIPPED means the source was unreachable — it did **not** validate your fix. The offline test from Step 6 is what proves the parser works. To prove **every** live file of that chain parses (not a sample of 10), follow **is-parsing-complete** (`.cursor/skills/is-parsing-complete/SKILL.md`).
 
 Then run `ReadLints` on the edited `parsers/<chain>.py`.
 

--- a/.cursor/skills/is-parsing-complete/SKILL.md
+++ b/.cursor/skills/is-parsing-complete/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: is-parsing-complete
+description: Parse every downloaded Israeli supermarket XML file and stop on the first parse or validation failure. Second-tier check after run-pytest (sampled live tests). Use when verifying files actually parse, diagnosing XML shape drift, list_key/id_field mismatches, or after a pytest PASS/SKIP.
+disable-model-invocation: true
+---
+
+# Parse / Validate Supermarket Files
+
+## Core principle
+
+**Pytest sampling ≠ parse completeness.**
+
+`run-pytest` downloads **10 files per type** (`NUM_SAMPLES=10`). A SKIPPED live-source test validated nothing (source unreachable / bot-protected).
+
+This skill downloads into a **fresh dump dir** and runs `parser.read()` + `run_validation()` on each file. Expectation:
+
+every readable file **parses and matches the XML** (row counts, id field, roots, unused keys)
+
+Stop at the **first** parse or validation failure. Do not keep parsing the rest of the chain.
+
+**Exception — empty files:** `is_expected_to_be_readable=False` (zero-byte) is skipped (`skipped_empty`) and does not fail-fast. Tiny files that are not expected to have records must parse to **zero rows**.
+
+## When to use
+
+| Use this skill | Use `run-pytest` / `fix-supermarket-parser` instead |
+|---|---|
+| Prove every file (or every type) parses | Fast sampled CI (`NUM_SAMPLES=10`) |
+| `columns chainid missing`, `id missing`, element count mismatch | Diagnose and patch `parsers/<chain>.py` |
+| After pytest PASS/SKIP, prove files parse | Unit/offline layout tests |
+| Exhaustive check without patching `test_case.py` `limit = None` | Never commit `limit = None` |
+
+Run pytest first when both matter. A pytest PASS with a parse FAIL is still a real bug. A SKIPPED pytest is **not** a PASS.
+
+## Do not confuse with sampled CI
+
+CI and `run-pytest` cap downloads at 10 files. That skip is **by design** — not proof the rest parse.
+
+This check uses a **fresh dump dir** and a scraper status path inside that dir, so daily-publish / leftover `status_logs` cannot hide missing files. Do **not** reuse a production dump or status JSON.
+
+Do **not** patch `il_supermarket_parsers/parsers/tests/test_case.py` to set `limit = None`. Use this helper instead.
+
+## Agent workflow
+
+1. Resolve `ParserFactory` names (user list, or one sample per engine).
+2. Run the helper (it instantiates via `ParserFactory.<NAME>.value`; scrape uses the matching `ScraperFactory` name):
+
+```bash
+python scripts/validate_parsing.py --parsers SHUFERSAL
+python scripts/validate_parsing.py --parsers SHUFERSAL,VICTORY_NEW_SOURCE
+python scripts/validate_parsing.py --per-engine
+python scripts/validate_parsing.py --all-listed --output scripts/validation_parsing.json
+```
+
+3. Default is **all files, all types**, fail-fast. File types run small-first (`STORE`, `PRICE`, `PROMO`, then `*_FULL`). Use `--limit N` or `--file-types PRICE_FILE` only when the user asks for a cheaper smoke.
+4. On **FAIL**: record `failed_file`, `failed_file_type`, `error`, how many succeeded before the stop. Stay on that chain; follow **fix-supermarket-parser** (inspect the XML, fix converter config, keep the old shape).
+5. On **PASS**: `failed=0` and `parsed > 0` (optional `skipped_empty > 0` is OK).
+
+## Checklist
+
+- [ ] Fresh dump dir (no leftover `status_logs` skip)
+- [ ] Real `parser.read()` + `run_validation()` (not pytest sample-only)
+- [ ] Stopped on first parse/validation failure (empty-file skips continue)
+- [ ] `parsed > 0` and `failed == 0` (PASS)
+- [ ] First failure includes filename + file type + error (FAIL)
+
+## Common issues
+
+| Symptom | Likely cause |
+|---|---|
+| `columns chainid missing` / empty DataFrame | Wrong `list_key` — see fix-supermarket-parser |
+| `id <x> missing from <columns>` | Wrong `id_field` |
+| `element count mismatch` | Need `SubRootedXmlDataFrameConverter` or ignore wrapper |
+| First file fails, rest not tried | Expected — fail-fast |
+| `skipped_empty` | Zero-byte dump; not a parser bug |
+| `no files parsed` | Scrape returned nothing; geo / source down — not a silent PASS |
+| Pytest SKIPPED, this FAIL | Source reachable now, or XML drifted — treat as a real parser bug |
+| Pytest PASS, this FAIL | Sample of 10 missed the bad file/type |

--- a/.cursor/skills/run-pytest/SKILL.md
+++ b/.cursor/skills/run-pytest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-pytest
-description: Run the pytest suite for the Israeli supermarket parsers repo, locally or via Docker. Use when running tests, checking test output, or verifying a specific chain passes. Covers fast path, Docker path, and exhaustive (unlimited samples) mode.
+description: Run the pytest suite for the Israeli supermarket parsers repo, locally or via Docker. Use when running tests, checking test output, or verifying a specific chain passes. Covers fast path and Docker path. For exhaustive parse completeness, use is-parsing-complete instead of NUM_SAMPLES=None.
 ---
 
 # Run pytest
@@ -39,28 +39,16 @@ Inside the image, `CMD` uses `-n 2`; only the local fast path above uses `-n aut
 
 ## Exhaustive mode (new source or uncertain parser)
 
-By default each test downloads **10 sample files** (`NUM_SAMPLES=10`). To fetch every file from a source, temporarily patch `il_supermarket_parsers/parsers/tests/test_case.py` lines 106-109:
+Pytest PASS with `NUM_SAMPLES=10` is **not** proof every file parses. A SKIPPED live-source test validated nothing.
 
-**Before:**
-```python
-try:
-    self.limit = int(os.environ.get("NUM_SAMPLES", 10))
-except ValueError:
-    self.limit = 10
-```
-
-**After:**
-```python
-self.limit = None
-```
-
-Then run only the affected chain:
+Do **not** patch `test_case.py` to set `limit = None` (that times out CI if committed). Use
+[is-parsing-complete](../is-parsing-complete/SKILL.md)
+(`scripts/validate_parsing.py`): fresh dump dir, all files, **stops on the first parse or validation failure**.
 
 ```bash
-python -m pytest il_supermarket_parsers/parsers/tests/test_all.py -vv -k "<ChainName>" 2>&1 | tee temp/pytest-run-full.txt
+python scripts/validate_parsing.py --parsers <ChainName>
+python scripts/validate_parsing.py --parsers <ChainName> --limit 1
 ```
-
-**Revert before committing** — `limit = None` causes CI to download unbounded data and time out.
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dist/
 il_supermarket_parser.egg-info/
 
 status_logs/*
+scripts/validation_parsing.json

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Scripts package (CLI helpers and their unit tests)."""

--- a/scripts/test_validate_parsing.py
+++ b/scripts/test_validate_parsing.py
@@ -1,0 +1,133 @@
+"""Unit tests for fail-fast parse validation helpers."""
+
+import unittest
+
+from il_supermarket_parsers.engines.base import BaseFileConverter
+from il_supermarket_parsers.engines.big_id import BigIDFileConverter
+from il_supermarket_parsers.engines.branches import BigIdBranchesFileConverter
+
+from scripts.validate_parsing import (
+    consume_until_failure,
+    engine_name,
+    is_empty_skip,
+    is_parse_ok,
+    resolve_file_types,
+)
+
+
+def _ok(name: str, file_type: str = "PRICE_FILE") -> dict:
+    """Successful parse result."""
+    return {
+        "file_name": name,
+        "file_type": file_type,
+        "parsed": True,
+        "skipped_empty": False,
+        "row_count": 3,
+        "error": None,
+    }
+
+
+def _fail(name: str, error: str, file_type: str = "PRICE_FILE") -> dict:
+    """Failed parse result."""
+    return {
+        "file_name": name,
+        "file_type": file_type,
+        "parsed": False,
+        "skipped_empty": False,
+        "row_count": 0,
+        "error": error,
+    }
+
+
+def _empty(name: str) -> dict:
+    """Zero-byte skip result."""
+    return {
+        "file_name": name,
+        "file_type": "PRICE_FILE",
+        "parsed": False,
+        "skipped_empty": True,
+        "row_count": 0,
+        "error": None,
+    }
+
+
+class TestParseHelpers(unittest.IsolatedAsyncioTestCase):
+    """Fail-fast contract for validate_parsing."""
+
+    def test_is_parse_ok_requires_parsed(self):
+        """Unreadable skips and errors are not a successful parse."""
+        self.assertTrue(is_parse_ok(_ok("a")))
+        self.assertFalse(is_parse_ok(_fail("a", "columns chainid missing")))
+        self.assertFalse(is_parse_ok(_empty("a")))
+        self.assertTrue(is_empty_skip(_empty("a")))
+        self.assertFalse(is_empty_skip(_fail("a", "id missing")))
+
+    def test_engine_name_picks_most_specific(self):
+        """Branches beats BigID beats Base."""
+        self.assertEqual(
+            engine_name(BigIdBranchesFileConverter), "BigIdBranchesFileConverter"
+        )
+        self.assertEqual(engine_name(BigIDFileConverter), "BigIDFileConverter")
+        self.assertEqual(engine_name(BaseFileConverter), "BaseFileConverter")
+
+    def test_resolve_file_types_orders_small_first(self):
+        """PRICE_FULL is parsed after STORE even if requested first."""
+        ordered = resolve_file_types("PRICE_FULL_FILE,STORE_FILE")
+        self.assertEqual(ordered, ["STORE_FILE", "PRICE_FULL_FILE"])
+
+    async def test_consume_stops_on_first_failure(self):
+        """Later files must not be pulled after the first failed result."""
+        pulled = []
+
+        async def results():
+            items = (
+                _ok("one"),
+                _ok("two"),
+                _fail("three", "columns chainid missing"),
+                _ok("four"),
+            )
+            for item in items:
+                pulled.append(item["file_name"])
+                yield item
+
+        summary = await consume_until_failure(results())
+        self.assertEqual(summary["parsed"], 2)
+        self.assertEqual(summary["failed"], 1)
+        self.assertTrue(summary["stopped_on_failure"])
+        self.assertEqual(summary["failed_file"], "three")
+        self.assertEqual(summary["error"], "columns chainid missing")
+        self.assertEqual(pulled, ["one", "two", "three"])
+
+    async def test_consume_skips_empty(self):
+        """Zero-byte dumps do not fail-fast the chain."""
+        pulled = []
+
+        async def results():
+            items = (_ok("one"), _empty("blank.xml"), _ok("three"))
+            for item in items:
+                pulled.append(item["file_name"])
+                yield item
+
+        summary = await consume_until_failure(results())
+        self.assertEqual(summary["parsed"], 2)
+        self.assertEqual(summary["skipped_empty"], 1)
+        self.assertEqual(summary["failed"], 0)
+        self.assertFalse(summary["stopped_on_failure"])
+        self.assertEqual(pulled, ["one", "blank.xml", "three"])
+
+    async def test_consume_all_ok(self):
+        """A full successful drain reports no failure."""
+
+        async def results():
+            yield _ok("one")
+            yield _ok("two")
+
+        summary = await consume_until_failure(results())
+        self.assertEqual(summary["parsed"], 2)
+        self.assertEqual(summary["failed"], 0)
+        self.assertEqual(summary["skipped_empty"], 0)
+        self.assertFalse(summary["stopped_on_failure"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_parsing.py
+++ b/scripts/validate_parsing.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Fail-fast parse check: download then parse files until the first failure.
+
+Expectation: every readable dump file parses and passes ``run_validation``.
+Stops scheduling more files after the first parse or validation error.
+
+Uses a fresh dump dir and scraper status path inside that dir, so leftover
+``status_logs`` / daily-publish state cannot hide missing files.
+
+Examples:
+  python scripts/validate_parsing.py --parsers SHUFERSAL
+  python scripts/validate_parsing.py --parsers SHUFERSAL,VICTORY_NEW_SOURCE
+  python scripts/validate_parsing.py --per-engine
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime
+import json
+import logging
+import os
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+import pandas as pd
+from il_supermarket_scarper import FileTypesFilters, ScarpingTask
+
+from il_supermarket_parsers.engines.base import BaseFileConverter
+from il_supermarket_parsers.parser_factory import ParserFactory
+from il_supermarket_parsers.utils import DataLoader, DumpFile, Logger
+
+# Smallest files first so a stores/price failure does not wait on PRICE_FULL.
+DEFAULT_TYPE_ORDER = (
+    FileTypesFilters.STORE_FILE.name,
+    FileTypesFilters.PRICE_FILE.name,
+    FileTypesFilters.PROMO_FILE.name,
+    FileTypesFilters.PRICE_FULL_FILE.name,
+    FileTypesFilters.PROMO_FULL_FILE.name,
+)
+
+
+def engine_name(cls) -> str:
+    """Most specific converter engine in the class MRO."""
+    names = {base.__name__ for base in cls.__mro__}
+    if "BigIdBranchesFileConverter" in names:
+        return "BigIdBranchesFileConverter"
+    if "BigIDFileConverter" in names:
+        return "BigIDFileConverter"
+    if "BaseFileConverter" in names:
+        return "BaseFileConverter"
+    return cls.__name__
+
+
+def listed_factory_members() -> List[str]:
+    """All ParserFactory members, including deprecated ones."""
+    return ParserFactory.all_parsers_name()
+
+
+def resolve_parsers(args: argparse.Namespace) -> List[str]:
+    """Resolve which parsers to parse-check."""
+    if args.parsers:
+        return [name.strip() for name in args.parsers.split(",") if name.strip()]
+    if args.all_listed:
+        return listed_factory_members()
+    if args.per_engine:
+        by_engine: Dict[str, List[str]] = defaultdict(list)
+        for name in listed_factory_members():
+            cls = getattr(ParserFactory, name).value
+            by_engine[engine_name(cls)].append(name)
+        return [names[0] for _, names in sorted(by_engine.items())]
+    raise SystemExit("Specify --per-engine, --all-listed, or --parsers")
+
+
+def resolve_file_types(raw: Optional[str]) -> List[str]:
+    """File types in fail-fast order. Default is every FileTypesFilters member."""
+    allowed = FileTypesFilters.all_types()
+    if not raw:
+        return [name for name in DEFAULT_TYPE_ORDER if name in allowed]
+    requested = [name.strip() for name in raw.split(",") if name.strip()]
+    unknown = [name for name in requested if name not in allowed]
+    if unknown:
+        raise SystemExit(f"Unknown file types: {unknown}. Allowed: {allowed}")
+    ordered = [name for name in DEFAULT_TYPE_ORDER if name in requested]
+    leftover = [name for name in requested if name not in ordered]
+    return ordered + leftover
+
+
+def is_parse_ok(result: Dict[str, Any]) -> bool:
+    """True when the file parsed and validated."""
+    return bool(result.get("parsed"))
+
+
+def is_empty_skip(result: Dict[str, Any]) -> bool:
+    """True when the dump is zero-byte / unreadable (not a parser bug)."""
+    return bool(result.get("skipped_empty"))
+
+
+def _empty_summary() -> Dict[str, Any]:
+    return {
+        "parsed": 0,
+        "failed": 0,
+        "skipped_empty": 0,
+        "stopped_on_failure": False,
+    }
+
+
+async def consume_until_failure(
+    results: AsyncGenerator[Dict[str, Any], None],
+) -> Dict[str, Any]:
+    """Drain parse results; stop at the first parse/validation failure.
+
+    Zero-byte files are skipped (counted, not failed).
+    """
+    summary = _empty_summary()
+    async for result in results:
+        if is_empty_skip(result):
+            summary["skipped_empty"] += 1
+            continue
+        if is_parse_ok(result):
+            summary["parsed"] += 1
+            if summary["parsed"] % 25 == 0:
+                print(f"    {summary['parsed']} ok...", flush=True)
+            continue
+        summary["failed"] = 1
+        summary["stopped_on_failure"] = True
+        summary["failed_file"] = result.get("file_name")
+        summary["failed_file_type"] = result.get("file_type")
+        summary["error"] = result.get("error")
+        break
+    return summary
+
+
+def _base_result(dump_file: DumpFile) -> Dict[str, Any]:
+    return {
+        "file_name": dump_file.file_name,
+        "file_type": dump_file.detected_filetype.name,
+        "parsed": False,
+        "skipped_empty": False,
+        "row_count": 0,
+        "error": None,
+    }
+
+
+async def parse_file(
+    parser: BaseFileConverter, dump_file: DumpFile
+) -> Dict[str, Any]:
+    """Parse one dump file and run XML validation when rows are expected."""
+    result = _base_result(dump_file)
+    if not dump_file.is_expected_to_be_readable:
+        result["skipped_empty"] = True
+        return result
+    try:
+        rows: List[dict] = []
+        async for row in parser.read(dump_file):
+            rows.append(row)
+        result["row_count"] = len(rows)
+        if dump_file.is_expected_to_have_records:
+            if not rows:
+                result["error"] = "no rows parsed"
+                return result
+            parser.run_validation(pd.DataFrame(rows), dump_file)
+        elif rows:
+            result["error"] = f"expected empty data, got {len(rows)} rows"
+            return result
+        result["parsed"] = True
+    except (
+        OSError,
+        TypeError,
+        ValueError,
+        RuntimeError,
+        KeyError,
+        AssertionError,
+        ET.ParseError,
+    ) as exc:
+        result["error"] = str(exc)
+    return result
+
+
+async def iter_parse_results(
+    parser: BaseFileConverter, files: List[DumpFile]
+) -> AsyncGenerator[Dict[str, Any], None]:
+    """Yield parse results in file order (caller stops via consume)."""
+    for dump_file in files:
+        yield await parse_file(parser, dump_file)
+
+
+def scrape_type(
+    enum_name: str,
+    dump_dir: str,
+    status_dir: str,
+    file_type: str,
+    limit: Optional[int],
+) -> None:
+    """Download one file type into ``dump_dir`` with a throwaway status DB."""
+    task = ScarpingTask(
+        enabled_scrapers=[enum_name],
+        files_types=[file_type],
+        multiprocessing=1,
+        output_configuration={
+            "output_mode": "disk",
+            "base_storage_path": dump_dir,
+        },
+        status_configuration={"database_type": "json", "base_path": status_dir},
+    )
+    task.start(limit=limit, when_date=datetime.datetime.now())
+    task.join()
+
+
+async def load_files(
+    dump_dir: str, enum_name: str, file_type: str
+) -> List[DumpFile]:
+    """List dump files for one parser × file type."""
+    files: List[DumpFile] = []
+    async for dump_file in DataLoader(folder=dump_dir).load(
+        enabled_scraper=[enum_name],
+        files_types=[file_type],
+    ):
+        files.append(dump_file)
+    return files
+
+
+def _merge_type_summary(total: Dict[str, Any], part: Dict[str, Any]) -> None:
+    total["parsed"] += part.get("parsed") or 0
+    total["skipped_empty"] += part.get("skipped_empty") or 0
+    if part.get("failed"):
+        total["failed"] = 1
+        total["stopped_on_failure"] = True
+        total["failed_file"] = part.get("failed_file")
+        total["failed_file_type"] = part.get("failed_file_type")
+        total["error"] = part.get("error")
+
+
+async def parse_one(
+    enum_name: str, limit: Optional[int], file_types: List[str]
+) -> Dict[str, Any]:
+    """Scrape then parse one factory member until the first failure."""
+    cls = getattr(ParserFactory, enum_name, None)
+    row: Dict[str, Any] = {
+        "parser": enum_name,
+        "engine": None,
+        "class": None,
+        "limit": limit,
+        "file_types": file_types,
+        "parsed": 0,
+        "failed": 0,
+        "skipped_empty": 0,
+        "pass": False,
+        "stopped_on_failure": False,
+    }
+    if cls is None:
+        row["error"] = f"Unknown parser {enum_name}"
+        return row
+    converter_cls = cls.value
+    row["engine"] = engine_name(converter_cls)
+    row["class"] = converter_cls.__name__
+    parser = converter_cls()
+    totals = _empty_summary()
+    with tempfile.TemporaryDirectory(prefix=f"parse_{enum_name}_") as tmp:
+        dump_dir = os.path.join(tmp, "dumps")
+        status_dir = os.path.join(tmp, "status")
+        os.makedirs(dump_dir, exist_ok=True)
+        os.makedirs(status_dir, exist_ok=True)
+        try:
+            for file_type in file_types:
+                print(f"    scraping {file_type}...", flush=True)
+                scrape_type(enum_name, dump_dir, status_dir, file_type, limit)
+                files = await load_files(dump_dir, enum_name, file_type)
+                part = await consume_until_failure(iter_parse_results(parser, files))
+                _merge_type_summary(totals, part)
+                if totals["failed"]:
+                    break
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            row["error"] = str(exc)
+            return row
+    row.update(totals)
+    if row.get("failed"):
+        row["pass"] = False
+    elif row["parsed"] == 0:
+        row["error"] = "no files parsed"
+        row["pass"] = False
+    else:
+        row["pass"] = True
+    return row
+
+
+def _quiet_logs() -> None:
+    level_name = os.environ.get("VALIDATE_LOG_LEVEL", "ERROR")
+    level = getattr(logging, level_name.upper(), logging.ERROR)
+    logging.getLogger("mylogger").setLevel(level)
+    Logger.logger.setLevel(level)
+
+
+async def run(
+    parsers: List[str], limit: Optional[int], file_types: List[str]
+) -> List[Dict[str, Any]]:
+    """Parse-check each parser and return per-chain result rows."""
+    _quiet_logs()
+    results = []
+    for name in parsers:
+        print(f"Parsing {name}...", flush=True)
+        row = await parse_one(name, limit, file_types)
+        status = "PASS" if row.get("pass") else "FAIL"
+        extra = ""
+        if row.get("failed_file"):
+            extra = (
+                f" file={row['failed_file']}"
+                f" type={row.get('failed_file_type')}"
+                f" error={row.get('error')}"
+            )
+        elif row.get("error"):
+            extra = f" error={row['error']}"
+        skipped = row.get("skipped_empty") or 0
+        skipped_extra = f" skipped_empty={skipped}" if skipped else ""
+        print(
+            f"  {status} engine={row.get('engine')} "
+            f"parsed={row.get('parsed')} failed={row.get('failed')}"
+            f"{skipped_extra}{extra}",
+            flush=True,
+        )
+        results.append(row)
+    return results
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    """Parse CLI arguments for fail-fast parse validation."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--per-engine",
+        action="store_true",
+        help="One sample parser per converter engine (includes deprecated)",
+    )
+    group.add_argument(
+        "--all-listed",
+        action="store_true",
+        help="Every ParserFactory member",
+    )
+    group.add_argument(
+        "--parsers",
+        help="Comma-separated ParserFactory names",
+    )
+    parser.add_argument(
+        "--file-types",
+        dest="file_types",
+        help="Comma-separated FileTypesFilters names (default: all, small-first)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max files per type (default: all). Prefer all unless smoking.",
+    )
+    parser.add_argument(
+        "--output",
+        default="scripts/validation_parsing.json",
+        help="JSON report path (default: scripts/validation_parsing.json)",
+    )
+    parser.add_argument(
+        "--fail-on-error",
+        action="store_true",
+        default=True,
+        help="Exit 1 if any parser failed (default)",
+    )
+    parser.add_argument(
+        "--no-fail-on-error",
+        action="store_false",
+        dest="fail_on_error",
+        help="Always exit 0 after writing the report",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Run parse checks, write JSON report, and exit non-zero on failures."""
+    args = parse_args(argv)
+    parsers = resolve_parsers(args)
+    file_types = resolve_file_types(args.file_types)
+    results = asyncio.run(run(parsers, args.limit, file_types))
+    out_dir = os.path.dirname(os.path.abspath(args.output))
+    os.makedirs(out_dir or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(results, handle, indent=2, ensure_ascii=False)
+    print(f"Wrote {args.output}", flush=True)
+
+    failed = [row for row in results if not row.get("pass")]
+    if args.fail_on_error and failed:
+        print(f"{len(failed)} parser(s) failed parse check", flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Pytest sampling and SKIPPED live tests do not prove every dump parses. Add a helper that downloads into a fresh dump dir and stops on the first parse or validation failure.