### PR TITLE
fix: Bina/Shemi promo zero-row parse gaps (#97 #96 #94 #92)

### DIFF
--- a/il_supermarket_parsers/parsers/other.py
+++ b/il_supermarket_parsers/parsers/other.py
@@ -8,6 +8,38 @@ from il_supermarket_parsers.documents import (
 
 from .confix import CofixFileConverter
 
+_BINA_SHEMI_PROMO_ROOTS = ["ChainID", "SubChainID", "StoreID", "BikoretNo"]
+
+
+def _bina_shemi_promo_converter(list_key):
+    """Promo converter for Bina/Shemi dumps (Maayan, Shuk Ahir, Super Sapir, Netiv Hased)."""
+    return XmlDataFrameConverter(
+        list_key=list_key,
+        id_field="PromotionID",
+        roots=_BINA_SHEMI_PROMO_ROOTS,
+        date_columns=["PromotionUpdateTime"],
+        ignore_column=["XmlDocVersion", "DllVerNo"],
+    )
+
+
+def _bina_shemi_promo_parser():
+    """<Promotions> is the published wrapper; <Sales> stays as the BigID legacy fallback."""
+    return ConditionalXmlDataFrameConverter(
+        option_a=_bina_shemi_promo_converter("Promotions"),
+        option_b=_bina_shemi_promo_converter("Sales"),
+        check_key="Promotions",
+    )
+
+
+class _BinaShemiPromoFileConverter(BaseFileConverter):
+    """Bina/Shemi chains whose promo files use ChainID / PromotionID / PromotionUpdateTime."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            promo_parser=_bina_shemi_promo_parser(),
+            promofull_parser=_bina_shemi_promo_parser(),
+        )
+
 
 class YaynoBitanFileConverter(BaseFileConverter):
     """
@@ -66,7 +98,7 @@ class KingStoreFileConverter(BaseFileConverter):
     """
 
 
-class Maayan2000FileConverter(BaseFileConverter):
+class Maayan2000FileConverter(_BinaShemiPromoFileConverter):
     """
     File converter for Maayan 2000 supermarket chain.
     Extends: BaseFileConverter
@@ -80,7 +112,7 @@ class MegaFileConverter(BaseFileConverter):
     """
 
 
-class NetivHasedFileConverter(BaseFileConverter):
+class NetivHasedFileConverter(_BinaShemiPromoFileConverter):
     """
     File converter for Netiv Hased supermarket chain.
     Extends: BaseFileConverter
@@ -129,7 +161,7 @@ class ShefaBarcartAshemFileConverter(BaseFileConverter):
     """
 
 
-class ShukAhirFileConverter(BaseFileConverter):
+class ShukAhirFileConverter(_BinaShemiPromoFileConverter):
     """
     File converter for Shuk Ahir supermarket chain.
     Extends: BaseFileConverter
@@ -164,7 +196,7 @@ class SuperYudaFileConverter(BaseFileConverter):
         )
 
 
-class SuperSapirFileConverter(BaseFileConverter):
+class SuperSapirFileConverter(_BinaShemiPromoFileConverter):
     """
     File converter for Super Sapir supermarket chain.
     Extends: BaseFileConverter

--- a/il_supermarket_parsers/tests/test_bina_shemi_promo_layouts.py
+++ b/il_supermarket_parsers/tests/test_bina_shemi_promo_layouts.py
@@ -1,0 +1,173 @@
+"""Offline regression tests for Bina/Shemi promo layout.
+
+Maayan, Shuk Ahir, Super Sapir, and Netiv Hased share this dump shape.
+
+These chains publish promo files under ``<Promotions>`` with ``ChainID`` /
+``PromotionID`` / ``PromotionUpdateTime``. Incremental Promo dumps are often a
+header plus an empty ``<Promotions></Promotions>`` wrapper (no daily changes).
+That is genuine empty XML, not a missing ``list_key``. Files that do contain
+promotions — and the BigID legacy ``<Sales>`` wrapper — must keep parsing.
+
+These tests run without network access, so they still guard the parser when the
+live-source tests in ``parsers/tests/test_all.py`` skip.
+"""
+
+import asyncio
+import os
+import tempfile
+import unittest
+
+from il_supermarket_parsers.parsers.other import (
+    Maayan2000FileConverter,
+    NetivHasedFileConverter,
+    ShukAhirFileConverter,
+    SuperSapirFileConverter,
+)
+from il_supermarket_parsers.utils.loading_utils import file_name_to_components
+
+_CONVERTERS = (
+    Maayan2000FileConverter,
+    NetivHasedFileConverter,
+    ShukAhirFileConverter,
+    SuperSapirFileConverter,
+)
+
+PROMO_PROMOTIONS_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<Root>
+  <ChainID>7290058159628</ChainID>
+  <SubChainID>000</SubChainID>
+  <StoreID>065</StoreID>
+  <BikoretNo>0</BikoretNo>
+  <Promotions>
+    <Promotion>
+      <PromotionUpdateTime>2026-09-03T17:03:10.734</PromotionUpdateTime>
+      <PromotionID>254332</PromotionID>
+      <PromotionDescription>Two for one</PromotionDescription>
+    </Promotion>
+    <Promotion>
+      <PromotionUpdateTime>2026-09-03T17:03:10.734</PromotionUpdateTime>
+      <PromotionID>254331</PromotionID>
+      <PromotionDescription>Half price</PromotionDescription>
+    </Promotion>
+  </Promotions>
+</Root>
+"""
+
+PROMO_SALES_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<Root>
+  <ChainID>7290058159628</ChainID>
+  <SubChainID>000</SubChainID>
+  <StoreID>065</StoreID>
+  <BikoretNo>0</BikoretNo>
+  <Sales>
+    <Sale>
+      <PromotionUpdateTime>2026-09-03T17:03:10.734</PromotionUpdateTime>
+      <PromotionID>8001</PromotionID>
+      <PromotionDescription>Bundle deal</PromotionDescription>
+    </Sale>
+  </Sales>
+</Root>
+"""
+
+PROMO_EMPTY_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<Root>
+  <ChainID>7290058159628</ChainID>
+  <SubChainID>000</SubChainID>
+  <StoreID>078</StoreID>
+  <BikoretNo>0</BikoretNo>
+  <Promotions></Promotions>
+</Root>
+"""
+
+
+async def _read_rows(converter_cls, folder, file_name):
+    """Parse one file with the given converter and return the rows."""
+    dump_file = file_name_to_components(folder, file_name)
+    parser = converter_cls()
+    return [row async for row in parser.read(dump_file)]
+
+
+def _parse(converter_cls, file_name, content):
+    """Write content to a temp folder and parse it."""
+    with tempfile.TemporaryDirectory() as folder:
+        with open(os.path.join(folder, file_name), "w", encoding="utf-8") as handle:
+            handle.write(content)
+        return asyncio.run(_read_rows(converter_cls, folder, file_name))
+
+
+class BinaShemiPromoLayoutTestCase(unittest.TestCase):
+    """Promotions, legacy Sales, and empty Promotions wrappers must all be handled."""
+
+    def _assert_ids(self, rows, expected_ids):
+        self.assertEqual(len(rows), len(expected_ids))
+        self.assertEqual([row["promotionid"] for row in rows], expected_ids)
+
+    def test_promo_promotions_layout(self):
+        """Promo using the current <Promotions> wrapper yields rows."""
+        for converter_cls in _CONVERTERS:
+            with self.subTest(converter=converter_cls.__name__):
+                rows = _parse(
+                    converter_cls,
+                    "Promo7290058159628-000-065-20260903-170052.xml",
+                    PROMO_PROMOTIONS_XML,
+                )
+                self._assert_ids(rows, ["254332", "254331"])
+                self.assertEqual(rows[0]["chainid"], "7290058159628")
+                self.assertEqual(rows[0]["storeid"], "065")
+
+    def test_promo_legacy_sales_layout(self):
+        """Promo using the BigID legacy <Sales> wrapper still yields rows."""
+        for converter_cls in _CONVERTERS:
+            with self.subTest(converter=converter_cls.__name__):
+                rows = _parse(
+                    converter_cls,
+                    "Promo7290058159628-000-065-20260903-170052.xml",
+                    PROMO_SALES_XML,
+                )
+                self._assert_ids(rows, ["8001"])
+
+    def test_promofull_promotions_layout(self):
+        """PromoFull using the current <Promotions> wrapper yields rows."""
+        for converter_cls in _CONVERTERS:
+            with self.subTest(converter=converter_cls.__name__):
+                rows = _parse(
+                    converter_cls,
+                    "PromoFull7290058159628-000-065-20260904-050352.xml",
+                    PROMO_PROMOTIONS_XML,
+                )
+                self._assert_ids(rows, ["254332", "254331"])
+
+    def test_promofull_legacy_sales_layout(self):
+        """PromoFull using the BigID legacy <Sales> wrapper still yields rows."""
+        for converter_cls in _CONVERTERS:
+            with self.subTest(converter=converter_cls.__name__):
+                rows = _parse(
+                    converter_cls,
+                    "PromoFull7290058159628-000-065-20260904-050352.xml",
+                    PROMO_SALES_XML,
+                )
+                self._assert_ids(rows, ["8001"])
+
+    def test_empty_promotions_is_not_a_wrong_list_key(self):
+        """An empty <Promotions/> wrapper yields zero rows for both Promo and PromoFull.
+
+        Live incremental dumps (and some stores with no promotions) publish this
+        exact document. The wrapper is present; there are simply no Promotion
+        children. A Sales-only parser would look the same (zero rows), so the
+        Promotions-with-data tests above are what prove the list_key.
+        """
+        for converter_cls in _CONVERTERS:
+            for file_name in (
+                "Promo7290058156016-000-078-20260902-083910.xml",
+                "PromoFull7290058148776-000-322-20260902-051138.xml",
+            ):
+                with self.subTest(converter=converter_cls.__name__, file_name=file_name):
+                    rows = _parse(converter_cls, file_name, PROMO_EMPTY_XML)
+                    self.assertEqual(rows, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Shuk Ahir, Maayan 2000, Netiv Hased, and Super Sapir publish promo XML as `<Promotions>` with `ChainID` / `PromotionID` / `PromotionUpdateTime`. Promo and PromoFull now use that schema, with `<Sales>` kept as a BigID legacy fallback via `ConditionalXmlDataFrameConverter`.
- Most files named in the quality gaps are **genuinely empty** (`<Promotions></Promotions>` with no children) — incremental dumps with no daily changes, or stores that publish no promotions. That is not a wrong `list_key`. Files that do contain promotions already parsed; this change pins the live field names so a wrapper drift cannot silently emit zero rows again.
- Offline tests cover both wrappers (current `<Promotions>` and legacy `<Sales>`) plus the empty-Promotions document, so a SKIPPED live-source test is not the only guard.

Fixes parse-gap reports:
- https://github.com/OpenIsraeliSupermarkets/israeli-supermarket-parsers/issues/97 (SHUK_AHIR)
- https://github.com/OpenIsraeliSupermarkets/israeli-supermarket-parsers/issues/96 (MAAYAN_2000)
- https://github.com/OpenIsraeliSupermarkets/israeli-supermarket-parsers/issues/94 (NETIV_HASED)
- https://github.com/OpenIsraeliSupermarkets/israeli-supermarket-parsers/issues/92 (SUPER_SAPIR)

## Per-issue root cause
| Issue | Chain | What the XML showed |
|---|---|---|
| #97 | SHUK_AHIR | Named Promo files and PromoFull store 322 are empty `<Promotions/>`. Other stores' PromoFull have hundreds of rows. |
| #96 | MAAYAN_2000 | Mix of empty incremental Promos (~208 bytes) and files with real `<Promotion>` children. Live files with data already yielded rows. |
| #94 | NETIV_HASED | Incremental `Promo7290058160839-*-*-20260902-*` files are empty `<Promotions/>`. PromoFull on the same site has 374+ promotions. |
| #92 | SUPER_SAPIR | Store 078 incrementals and named PromoFull stores (078/262/277/396/029) are empty `<Promotions/>`. Other stores have promotions. |

## Test plan
- [x] `pytest il_supermarket_parsers/tests/test_bina_shemi_promo_layouts.py` — Promotions, Sales, empty wrapper (5 passed)
- [x] pylint on edited files — 10.00/10
- [x] Live chain tests: Shuk Ahir and Super Sapir promo/promofull passed; Maayan/Netiv incremental promo skipped when the source listed no files; PromoFull passed for all four
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)